### PR TITLE
Updated API regarding documentation on uship

### DIFF
--- a/lib/uship.js
+++ b/lib/uship.js
@@ -27,7 +27,7 @@ var uShip = function(key, secret, username, password){
     secret,
     'https://api.uship.com',
     null,
-    '/oauth/token_authenticated',
+    '/oauth/token',
     null
   );
 }
@@ -37,7 +37,7 @@ uShip.prototype._getOAuthAccessToken = function(){
 
   return when.promise(function(resolve, reject){
     var options = {
-        grant_type: 'password',
+        grant_type: 'client_credentials',
         username: uship.username,
         password: uship.password
       };


### PR DESCRIPTION
Current implementation didn't work for me. So I read uShip doc and updated it. 
- Would be nice to have a sandbox key for testing, because my key didn't support  "rateRequests" so I couldn't test that. 
- Estimate endpoint works as expected.
