### PR TITLE
Removed unused libraries and fixed the error message

### DIFF
--- a/lib/uship.js
+++ b/lib/uship.js
@@ -1,7 +1,5 @@
 var when = require("when");
 var request = require("request");
-var _ = require("underscore");
-var S = require("string");
 var OAuth2 = require('oauth').OAuth2;
 
 // Error technique from
@@ -90,7 +88,7 @@ uShip.prototype.post = function(path, data, attempt){
             uship.access_token = null;
             return resolve(uship.post(path, data, attempt + 1));
           }
-          return reject(new uShipError(S(body).stripTags()));
+          return reject(new uShipError(JSON.stringify(body)));
         }
 
         if (response.headers.location != undefined) {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
   "keywords": [],
   "dependencies": {
     "when": "3.4.3",
-    "underscore": "1.7.0",
     "oauth": "0.9.12",
-    "request": "2.47.0",
-    "string": "2.2.0"
+    "request": "2.47.0"
   },
   "noAnalyze": true,
   "license": "MIT",


### PR DESCRIPTION
Removed unused libraries like "string" and "underscore" and made errors return actual errors(Before the error was expected to be a html fragment, that would be stripped of it's tags). Starting from v2 it's all JSON.
